### PR TITLE
Fixes internet-access for apt on some devices

### DIFF
--- a/scripts/create.sh
+++ b/scripts/create.sh
@@ -9,6 +9,7 @@ groupmod -g 100000 nemo
 # Make network connections works if CONFIG_ANDROID_PARANOID_NETWORK is enabled
 groupadd -g 3003 inet
 usermod -aG inet nemo 
+usermod -g inet _apt
 
 su - nemo -c "mkdir -p /home/nemo/.config/ ; #mkdir /home/nemo/.config/pulse"
 


### PR DESCRIPTION
My Xperia-X couldn't run the apt-commands unless I added this.

I got the solution from [here](https://askubuntu.com/questions/910865/apt-get-update-fails-on-chroot-ubuntu-16-04-on-android/932229). I don't think that this breaks anything on other devices but I'm not fully certain.